### PR TITLE
Fix password composition check

### DIFF
--- a/lib/canvas_customize_passwords/canvas_extensions/password_policy.rb
+++ b/lib/canvas_customize_passwords/canvas_extensions/password_policy.rb
@@ -4,7 +4,7 @@ module CanvasCustomizePasswords
       def self.validate(record, attr, value)
         policy = record.account.password_policy
         value = value.to_s
-        if policy[:enforce_password_composition_rules]
+        if policy[:enforce_password_composition_rules] && record.is_a?(Pseudonym) && !record.password_auto_generated
           uppercase = !(value =~ /[A-Z]/)
           lowercase = !(value =~ /[a-z]/)
           numerical = !(value =~ /[0-9]/)


### PR DESCRIPTION
Something changed with Canvas recently.
The auto generated password sometimes have a special characer (_) and sometimes don't. Example where it fails: `CVgJYAkrbErPNKJkYmbK`
Example where it succeeds: `NSaNz6JG_5IcqxdJ6D34`

This change just checks that our validator won't activate on an auto generated password. They are strong enough without that underscore.