### PR TITLE
Move passwords to new module

### DIFF
--- a/lib/canvas_customize_passwords/engine.rb
+++ b/lib/canvas_customize_passwords/engine.rb
@@ -44,7 +44,7 @@ module CanvasCustomizePasswords
       )
 
       if ActiveRecord::Base.connection.table_exists?("plugin_settings") && Canvas::Plugin.find(:canvas_customize_passwords).enabled?
-        Canvas::PasswordPolicy.define_singleton_method :default_policy do
+        Canvas::Security::PasswordPolicy.define_singleton_method :default_policy do
           @plugin ||= PluginSetting.find_by(name: "canvas_customize_passwords")
           min_length = @plugin.settings[:min_length].present? ? @plugin.settings[:min_length].to_i : 12
           max_repeats = @plugin.settings[:max_repeats].present? ? @plugin.settings[:max_repeats].to_i : 2
@@ -60,9 +60,9 @@ module CanvasCustomizePasswords
           }
         end
 
-        Canvas::PasswordPolicy.define_singleton_method :validate_original, &Canvas::PasswordPolicy.method(:validate)
+        Canvas::Security::PasswordPolicy.define_singleton_method :validate_original, &Canvas::Security::PasswordPolicy.method(:validate)
 
-        Canvas::PasswordPolicy.define_singleton_method :validate do |record, attr, value|
+        Canvas::Security::PasswordPolicy.define_singleton_method :validate do |record, attr, value|
           CanvasExtensions::PasswordPolicy.validate(record, attr, value)
           validate_original(record, attr, value)
         end


### PR DESCRIPTION
This moves the password policy plugin to the new location in the `Canvas::Security` module.  Canvas has some customization capabilities built in now, which do conflict with these if they're both enabled.  However, enabling only this one is safe, and I haven't yet been able to customize the policy using the native one if it's enabled at all.