### PR TITLE
Version 2.0.0 of plugin

### DIFF
--- a/lib/canvas_customize_passwords/version.rb
+++ b/lib/canvas_customize_passwords/version.rb
@@ -1,3 +1,3 @@
 module CanvasCustomizePasswords
-  Version = "1.1.0"
+  Version = "2.0.0"
 end


### PR DESCRIPTION
Forgot to bump version.  This moves to 2.0.0 as a major release since the location of the plugin module changed entirely, and is incompatible with certain versions of Canvas prior to their change (2024-07-03)